### PR TITLE
HTTP Basic Auth -> Supression of modal window

### DIFF
--- a/firefox-webdriver.scm
+++ b/firefox-webdriver.scm
@@ -29,6 +29,7 @@
     (extensions.update.notifyUser . "false")
     (network.manage-offline-status . "false")
     (network.http.max-connections-per-server . "10")
+    (network.http.phishy-userpass-length . "255")
     (prompts.tab_modal.enabled . "false")
     (security.fileuri.origin_policy . "3")
     (security.fileuri.strict_origin_policy . "false")


### PR DESCRIPTION
A real-life scenario:
We have a site locked with HTTP Basic Auth which we want to test with the selenium egg. 
We point the browser to the site with the proper credentials:

```
(set-url! "http://someuser:somepassword@localhost:8888")
```

And the browser opens up a window saying: 

> You are about to log in to the site 'localhost' with the username 'someuser'. 

The webdriver just hangs there, not knowing how to deal with this dialog. 
The solution is to set the user preference **network.http.phishy-userpass-length** to a high value (like 255) as suggested [here](http://kb.mozillazine.org/Network.http.phishy-userpass-length). This patch does just that.
